### PR TITLE
fix(tools): add dummy CI backend for non-backend changes

### DIFF
--- a/.github/workflows/ci-dummy-workflow.yaml
+++ b/.github/workflows/ci-dummy-workflow.yaml
@@ -1,0 +1,31 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'api/**'
+      - '.github/workflows/ci-backend.yaml'
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - 'api/**'
+      - '.github/workflows/ci-backend.yaml'
+
+jobs:
+  # Job 1
+  static-analysis:
+    name: Lint, Format & Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skips tests for non-backend changes
+        run: echo "No backend changes detected. Skipping tests."
+
+  # Job 2: Runs only if static-analysis passes. 
+  unit-tests:
+    name: Run Unit Tests
+    needs: static-analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skips tests for non-backend changes
+        run: echo "No backend changes detected. Skipping tests."


### PR DESCRIPTION
## Related Issue
Closes #13 

## Context & Intent
- To fix the PR lock (due to the CI backend pipeline) when requested on changes that do not affect the backend part.

## What Changed
- Added dummy CI for non-backend changes.