### PR TITLE
fix(tools): fix mismatch between pre-commit and local ruff formatting

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 [tool.ruff]
 target-version = "py314"
 line-length = 88
+src = ["src"]
 
 [tool.ruff.format]
 preview = true
@@ -66,6 +67,9 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "D"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["babylon", "tests"]
 
 [tool.mypy]
 python_version = "3.14"


### PR DESCRIPTION
## Related Issue
Closes #16 

## Context & Intent
- The pre-commit pipeline was acting different than the local QA pipleine. The main difference was that babylon was sometimes considered a first-party package and sometimes not, depending on the root of the execution.

## What Changed
- Forced ruff to considere babylon as a first-party package

## Testing Executed
- [x] Static analysis Ruff passed (both on pre-commit and locally)