### PR TITLE
feat(application): add use case and related unit test

### DIFF
--- a/api/src/babylon/application/__init__.py
+++ b/api/src/babylon/application/__init__.py
@@ -1,8 +1,1 @@
 """Application layer for Babylon backend."""
-
-from babylon.application.exceptions import ApplicationError, DatabaseUnavailableError
-
-__all__ = [
-    "ApplicationError",
-    "DatabaseUnavailableError",
-]

--- a/api/src/babylon/application/exceptions.py
+++ b/api/src/babylon/application/exceptions.py
@@ -4,9 +4,27 @@
 class ApplicationError(Exception):
     """Base class for application-layer exceptions."""
 
+    pass
 
-class DatabaseUnavailableError(ApplicationError):
-    """Raised when the database is unreachable or unavailable."""
 
-    def __init__(self, message: str = "Database is unavailable.") -> None:
-        super().__init__(message)
+class UsernameAlreadyExistsError(ApplicationError):
+    """Raised when attempting to register a username that is already taken."""
+
+    def __init__(self, username: str) -> None:
+        self.username = username
+        super().__init__(f"User with username '{username}' already exists.")
+
+
+class InvalidCredentialsError(ApplicationError):
+    """Raised when authentication fails due to incorrect username or password."""
+
+    def __init__(self) -> None:
+        super().__init__("Invalid username or password.")
+
+
+class UserNotFoundError(ApplicationError):
+    """Raised when attempting to operate on a user ID that does not exist."""
+
+    def __init__(self, user_id: str) -> None:
+        self.user_id = user_id
+        super().__init__(f"User with ID '{user_id}' not found.")

--- a/api/src/babylon/application/ports/salt_generator.py
+++ b/api/src/babylon/application/ports/salt_generator.py
@@ -1,0 +1,12 @@
+"""Interfaces requiring external implementations."""
+
+from abc import ABC, abstractmethod
+
+
+class IFakeSaltGenerator(ABC):
+    """Generates deterministic fake salts to prevent User Enumeration."""
+
+    @abstractmethod
+    def generate_fallback_salt(self, username: str) -> str:
+        """Generate a fake salt deterministically based on the username."""
+        pass

--- a/api/src/babylon/application/use_cases/__init__.py
+++ b/api/src/babylon/application/use_cases/__init__.py
@@ -1,0 +1,1 @@
+"""Use cases for the Babylon application."""

--- a/api/src/babylon/application/use_cases/authentication/__init__.py
+++ b/api/src/babylon/application/use_cases/authentication/__init__.py
@@ -1,0 +1,10 @@
+"""Authentication use cases package."""
+
+from .authenticate_user import AuthenticateUser
+from .dtos import AuthenticateUserQueryDTO, AuthenticateUserResponseDTO
+
+__all__ = [
+    "AuthenticateUser",
+    "AuthenticateUserQueryDTO",
+    "AuthenticateUserResponseDTO",
+]

--- a/api/src/babylon/application/use_cases/authentication/authenticate_user.py
+++ b/api/src/babylon/application/use_cases/authentication/authenticate_user.py
@@ -1,0 +1,34 @@
+"""AuthenticateUser Use Case."""
+
+from babylon.application.exceptions import InvalidCredentialsError
+from babylon.domain.ports.unit_of_work import UnitOfWork
+from babylon.domain.value_objects import ServerAuthHash, Username
+
+from .dtos import AuthenticateUserQueryDTO, AuthenticateUserResponseDTO
+
+
+class AuthenticateUser:
+    """Use case for authenticating a user."""
+
+    def __init__(self, uow: UnitOfWork):
+        self._uow = uow
+
+    async def __call__(
+        self, dto: AuthenticateUserQueryDTO
+    ) -> AuthenticateUserResponseDTO:
+        """Authenticate a user based on provided credentials."""
+        async with self._uow as uow:
+            username = Username(dto.username)
+            user = await uow.users.find_by_username(username)
+
+            if user is None:
+                raise InvalidCredentialsError()
+
+            provided_hash = ServerAuthHash(dto.server_auth_hash)
+
+            # Using entity's value object exact match to verify the credentials.
+            # Value Object comparison natively works if implemented appropriately.
+            if user.server_authentication_hash != provided_hash:
+                raise InvalidCredentialsError()
+
+            return AuthenticateUserResponseDTO(user_id=str(user.id.value))

--- a/api/src/babylon/application/use_cases/authentication/dtos.py
+++ b/api/src/babylon/application/use_cases/authentication/dtos.py
@@ -1,0 +1,18 @@
+"""Data Transfer Objects for Authentication Use Cases."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AuthenticateUserQueryDTO:
+    """Input Data Transfer Object for authenticating a user."""
+
+    username: str
+    server_auth_hash: str
+
+
+@dataclass(frozen=True)
+class AuthenticateUserResponseDTO:
+    """Output Data Transfer Object for authenticating a user."""
+
+    user_id: str

--- a/api/src/babylon/application/use_cases/credential_rotation/__init__.py
+++ b/api/src/babylon/application/use_cases/credential_rotation/__init__.py
@@ -1,0 +1,9 @@
+"""Rotate Credentials use cases package."""
+
+from .dtos import RotateCredentialsCommandDTO
+from .rotate_credentials import RotateCredentials
+
+__all__ = [
+    "RotateCredentials",
+    "RotateCredentialsCommandDTO",
+]

--- a/api/src/babylon/application/use_cases/credential_rotation/dtos.py
+++ b/api/src/babylon/application/use_cases/credential_rotation/dtos.py
@@ -1,0 +1,16 @@
+"""Data Transfer Objects for Rotate Credentials Use Cases."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RotateCredentialsCommandDTO:
+    """Input Data Transfer Object for rotating user credentials."""
+
+    user_id: str
+    current_server_auth_hash: str
+    new_salt: str
+    new_server_auth_hash: str
+    new_kdf_memory_cost: int
+    new_kdf_time_cost: int
+    new_kdf_parallelism: int

--- a/api/src/babylon/application/use_cases/credential_rotation/rotate_credentials.py
+++ b/api/src/babylon/application/use_cases/credential_rotation/rotate_credentials.py
@@ -1,0 +1,49 @@
+"""RotateCredentials Use Case."""
+
+import uuid
+
+from babylon.application.exceptions import InvalidCredentialsError, UserNotFoundError
+from babylon.domain.ports.unit_of_work import UnitOfWork
+from babylon.domain.value_objects import (
+    KdfConfiguration,
+    MasterPasswordSalt,
+    ServerAuthHash,
+    UserId,
+)
+
+from .dtos import RotateCredentialsCommandDTO
+
+
+class RotateCredentials:
+    """Use case for rotating user credentials."""
+
+    def __init__(self, uow: UnitOfWork):
+        self._uow = uow
+
+    async def __call__(self, dto: RotateCredentialsCommandDTO) -> None:
+        """Rotate user credentials based on provided information."""
+        async with self._uow as uow:
+            # Domain exception will automatically raise if UUID is malformed
+            user_id = UserId(uuid.UUID(dto.user_id))
+            user = await uow.users.find_by_id(user_id)
+
+            if user is None:
+                raise UserNotFoundError(dto.user_id)
+
+            current_hash = ServerAuthHash(dto.current_server_auth_hash)
+            if user.server_authentication_hash != current_hash:
+                raise InvalidCredentialsError()
+
+            new_salt = MasterPasswordSalt(dto.new_salt)
+            new_hash = ServerAuthHash(dto.new_server_auth_hash)
+            new_kdf = KdfConfiguration(
+                algorithm="argon2id",
+                memory_kb=dto.new_kdf_memory_cost,
+                iterations=dto.new_kdf_time_cost,
+                parallelism=dto.new_kdf_parallelism,
+            )
+
+            user.rotate_credentials(new_salt, new_hash, new_kdf)
+
+            await uow.users.save(user)
+            await uow.commit()

--- a/api/src/babylon/application/use_cases/registration/__init__.py
+++ b/api/src/babylon/application/use_cases/registration/__init__.py
@@ -1,0 +1,19 @@
+"""Rotate Credentials use cases package."""
+
+from .dtos import (
+    GetLoginOptionsQueryDTO,
+    GetLoginOptionsResponseDTO,
+    RegisterUserCommandDTO,
+    RegisterUserResponseDTO,
+)
+from .get_login_options import GetLoginOptions
+from .register_user import RegisterUser
+
+__all__ = [
+    "GetLoginOptions",
+    "GetLoginOptionsQueryDTO",
+    "GetLoginOptionsResponseDTO",
+    "RegisterUser",
+    "RegisterUserCommandDTO",
+    "RegisterUserResponseDTO",
+]

--- a/api/src/babylon/application/use_cases/registration/dtos.py
+++ b/api/src/babylon/application/use_cases/registration/dtos.py
@@ -1,0 +1,39 @@
+"""Data Transfer Objects for Rotate Credentials Use Cases."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RegisterUserCommandDTO:
+    """Input Data Transfer Object for registering a new user."""
+
+    username: str
+    server_auth_hash: str
+    salt: str
+    kdf_memory_cost: int
+    kdf_time_cost: int
+    kdf_parallelism: int
+
+
+@dataclass(frozen=True)
+class RegisterUserResponseDTO:
+    """Output Data Transfer Object for registering a new user."""
+
+    user_id: str
+
+
+@dataclass(frozen=True)
+class GetLoginOptionsQueryDTO:
+    """Input Data Transfer Object for retrieving login options."""
+
+    username: str
+
+
+@dataclass(frozen=True)
+class GetLoginOptionsResponseDTO:
+    """Output Data Transfer Object for retrieving login options."""
+
+    salt: str
+    kdf_memory_cost: int
+    kdf_time_cost: int
+    kdf_parallelism: int

--- a/api/src/babylon/application/use_cases/registration/get_login_options.py
+++ b/api/src/babylon/application/use_cases/registration/get_login_options.py
@@ -1,0 +1,40 @@
+"""GetLoginOptions Use Case."""
+
+from babylon.application.ports.salt_generator import IFakeSaltGenerator
+from babylon.domain.ports.unit_of_work import UnitOfWork
+from babylon.domain.value_objects import Username
+
+from .dtos import GetLoginOptionsQueryDTO, GetLoginOptionsResponseDTO
+
+
+class GetLoginOptions:
+    """Use case for retrieving login options for a given username."""
+
+    def __init__(self, uow: UnitOfWork, salt_generator: IFakeSaltGenerator):
+        self._uow = uow
+        self._salt_generator = salt_generator
+
+    async def __call__(
+        self, dto: GetLoginOptionsQueryDTO
+    ) -> GetLoginOptionsResponseDTO:
+        """Retrieve login options for a given username."""
+        async with self._uow as uow:
+            username = Username(dto.username)
+            user = await uow.users.find_by_username(username)
+
+            if user:
+                return GetLoginOptionsResponseDTO(
+                    salt=user.salt.value,
+                    kdf_memory_cost=user.kdf_configuration.memory_kb,
+                    kdf_time_cost=user.kdf_configuration.iterations,
+                    kdf_parallelism=user.kdf_configuration.parallelism,
+                )
+
+            # Security requirement: Prevent user enumeration
+            fake_salt = self._salt_generator.generate_fallback_salt(dto.username)
+            return GetLoginOptionsResponseDTO(
+                salt=fake_salt,
+                kdf_memory_cost=65536,
+                kdf_time_cost=3,
+                kdf_parallelism=4,
+            )

--- a/api/src/babylon/application/use_cases/registration/register_user.py
+++ b/api/src/babylon/application/use_cases/registration/register_user.py
@@ -1,0 +1,51 @@
+"""RegisterUser Use Case."""
+
+import uuid
+
+from babylon.application.exceptions import UsernameAlreadyExistsError
+from babylon.domain.entities import User
+from babylon.domain.ports.unit_of_work import UnitOfWork
+from babylon.domain.value_objects import (
+    AggregateVersion,
+    KdfConfiguration,
+    MasterPasswordSalt,
+    ServerAuthHash,
+    UserId,
+    Username,
+)
+
+from .dtos import RegisterUserCommandDTO, RegisterUserResponseDTO
+
+
+class RegisterUser:
+    """Use case for registering a new user."""
+
+    def __init__(self, uow: UnitOfWork):
+        self._uow = uow
+
+    async def __call__(self, dto: RegisterUserCommandDTO) -> RegisterUserResponseDTO:
+        """Register a new user based on provided information."""
+        async with self._uow as uow:
+            username = Username(dto.username)
+            existing_user = await uow.users.find_by_username(username)
+            if existing_user is not None:
+                raise UsernameAlreadyExistsError(dto.username)
+
+            user = User(
+                id=UserId(uuid.uuid7()),
+                version=AggregateVersion(1),
+                username=username,
+                salt=MasterPasswordSalt(dto.salt),
+                server_authentication_hash=ServerAuthHash(dto.server_auth_hash),
+                kdf_configuration=KdfConfiguration(
+                    algorithm="argon2id",
+                    memory_kb=dto.kdf_memory_cost,
+                    iterations=dto.kdf_time_cost,
+                    parallelism=dto.kdf_parallelism,
+                ),
+            )
+
+            await uow.users.save(user)
+            await uow.commit()
+
+            return RegisterUserResponseDTO(user_id=str(user.id.value))

--- a/api/src/babylon/infrastructure/database/exceptions.py
+++ b/api/src/babylon/infrastructure/database/exceptions.py
@@ -1,0 +1,14 @@
+"""Database-related exceptions for the Babylon backend."""
+
+
+class DatabaseError(Exception):
+    """Base class for database-related exceptions."""
+
+    pass
+
+
+class DatabaseUnavailableError(DatabaseError):
+    """Raised when the database is unreachable or unavailable."""
+
+    def __init__(self, message: str = "Database is unavailable.") -> None:
+        super().__init__(message)

--- a/api/src/babylon/infrastructure/database/repositories/user_repository.py
+++ b/api/src/babylon/infrastructure/database/repositories/user_repository.py
@@ -7,7 +7,6 @@ from sqlalchemy.exc import IntegrityError, OperationalError, TimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.exc import StaleDataError
 
-from babylon.application import DatabaseUnavailableError
 from babylon.domain.entities import User
 from babylon.domain.exceptions import UserAlreadyExistsError, UserConcurrencyError
 from babylon.domain.ports import UserRepository
@@ -19,6 +18,7 @@ from babylon.domain.value_objects import (
     UserId,
     Username,
 )
+from babylon.infrastructure.database.exceptions import DatabaseUnavailableError
 from babylon.infrastructure.database.models import UserModel
 
 _UNIQUE_VIOLATION_CODE = "23505"

--- a/api/src/babylon/infrastructure/database/uow.py
+++ b/api/src/babylon/infrastructure/database/uow.py
@@ -8,10 +8,10 @@ from collections.abc import Callable
 from sqlalchemy.exc import OperationalError, TimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from babylon.application import DatabaseUnavailableError
 from babylon.domain.entities import User
 from babylon.domain.ports import UnitOfWork, UserRepository
 from babylon.domain.value_objects import UserId, Username
+from babylon.infrastructure.database.exceptions import DatabaseUnavailableError
 from babylon.infrastructure.database.repositories.user_repository import (
     SqlAlchemyUserRepository,
 )

--- a/api/tests/unit/application/conftest.py
+++ b/api/tests/unit/application/conftest.py
@@ -1,0 +1,50 @@
+import uuid
+from collections.abc import Callable
+
+import pytest
+
+from babylon.domain.entities import User
+from babylon.domain.value_objects import (
+    AggregateVersion,
+    KdfConfiguration,
+    MasterPasswordSalt,
+    ServerAuthHash,
+    UserId,
+    Username,
+)
+
+from .fakes import FakeSaltGenerator, FakeUnitOfWork
+
+VALID_PHC_HASH_CONSTANT = (
+    "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$bm90YWhhc2h0aGF0aXNsb25nZW5vdWdoMTIzNA"
+)
+
+
+@pytest.fixture
+def valid_phc_hash() -> str:
+    return VALID_PHC_HASH_CONSTANT
+
+
+@pytest.fixture
+def uow() -> FakeUnitOfWork:
+    return FakeUnitOfWork()
+
+
+@pytest.fixture
+def salt_generator() -> FakeSaltGenerator:
+    return FakeSaltGenerator()
+
+
+@pytest.fixture
+def user_factory(valid_phc_hash: str) -> Callable[[str, str, int], User]:
+    def _create_user(username: str, salt: str = "B" * 32, kdf_mem: int = 65536) -> User:
+        return User(
+            id=UserId(uuid.uuid7()),
+            version=AggregateVersion(1),
+            username=Username(username),
+            salt=MasterPasswordSalt(salt),
+            server_authentication_hash=ServerAuthHash(valid_phc_hash),
+            kdf_configuration=KdfConfiguration("argon2id", kdf_mem, 3, 4),
+        )
+
+    return _create_user

--- a/api/tests/unit/application/fakes.py
+++ b/api/tests/unit/application/fakes.py
@@ -1,0 +1,44 @@
+"""Fake implementations for Application Layer unit tests."""
+
+from uuid import UUID
+
+from babylon.application.ports.salt_generator import IFakeSaltGenerator
+from babylon.domain.entities import User
+from babylon.domain.ports.unit_of_work import UnitOfWork
+from babylon.domain.ports.user_repository import UserRepository
+from babylon.domain.value_objects import UserId, Username
+
+
+class FakeUserRepository(UserRepository):
+    def __init__(self) -> None:
+        self._users: dict[UUID, User] = {}
+
+    async def save(self, user: User) -> None:
+        self._users[user.id.value] = user
+
+    async def find_by_id(self, id: UserId) -> User | None:
+        return self._users.get(id.value)
+
+    async def find_by_username(self, username: Username) -> User | None:
+        for u in self._users.values():
+            if u.username == username:
+                return u
+        return None
+
+
+class FakeUnitOfWork(UnitOfWork):
+    def __init__(self, repository: UserRepository | None = None) -> None:
+        self.users = repository or FakeUserRepository()
+        self.committed = False
+        self.rolled_back = False
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def rollback(self) -> None:
+        self.rolled_back = True
+
+
+class FakeSaltGenerator(IFakeSaltGenerator):
+    def generate_fallback_salt(self, username: str) -> str:
+        return f"fake_salt_{username}"

--- a/api/tests/unit/application/test_authenticate_user.py
+++ b/api/tests/unit/application/test_authenticate_user.py
@@ -1,0 +1,59 @@
+import pytest
+
+from babylon.application.exceptions import InvalidCredentialsError
+from babylon.application.use_cases.authentication import (
+    AuthenticateUser,
+    AuthenticateUserQueryDTO,
+    AuthenticateUserResponseDTO,
+)
+
+
+class TestAuthenticateUser:
+    @pytest.mark.asyncio
+    async def test_authenticate_user_happy_path(
+        self, uow, user_factory, valid_phc_hash
+    ):
+        existing_user = user_factory("test.user")
+        await uow.users.save(existing_user)
+
+        use_case = AuthenticateUser(uow)
+        dto = AuthenticateUserQueryDTO(
+            username="test.user", server_auth_hash=valid_phc_hash
+        )
+
+        response = await use_case(dto)
+        assert isinstance(response, AuthenticateUserResponseDTO)
+        assert response.user_id == str(existing_user.id.value)
+        assert not uow.committed
+        assert not uow.rolled_back
+
+    @pytest.mark.asyncio
+    async def test_authenticate_user_sad_path_not_found(self, uow, valid_phc_hash):
+        use_case = AuthenticateUser(uow)
+        dto = AuthenticateUserQueryDTO(
+            username="nonexistent.user", server_auth_hash=valid_phc_hash
+        )
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case(dto)
+        assert not uow.committed
+        assert uow.rolled_back
+
+    @pytest.mark.asyncio
+    async def test_authenticate_user_sad_path_wrong_hash(self, uow, user_factory):
+        existing_user = user_factory("test.user")
+        await uow.users.save(existing_user)
+
+        use_case = AuthenticateUser(uow)
+
+        new_valid_phc_hash = "$argon2id$v=19$m=65536,\
+t=3,p=4$c29tZXNhbHQ$d3Jvbmdhbndlcndyb25nYW53ZXJ3cm9uZ2Fud2Vyd3Jv"
+
+        dto = AuthenticateUserQueryDTO(
+            username="test.user", server_auth_hash=new_valid_phc_hash
+        )
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case(dto)
+        assert not uow.committed
+        assert uow.rolled_back

--- a/api/tests/unit/application/test_get_login_options.py
+++ b/api/tests/unit/application/test_get_login_options.py
@@ -1,0 +1,47 @@
+import pytest
+
+from babylon.application.use_cases.registration import (
+    GetLoginOptions,
+    GetLoginOptionsQueryDTO,
+    GetLoginOptionsResponseDTO,
+)
+
+
+class TestGetLoginOptions:
+    @pytest.mark.asyncio
+    async def test_get_login_options_user_exists(
+        self, uow, salt_generator, user_factory
+    ):
+        valid_base64_salt = "UkVBTF9TQUxUX1ZBTFVFXzEyM19SRUFMX1NBTFRfMTI="
+        existing_user = user_factory(
+            "existing.user", salt=valid_base64_salt, kdf_mem=100000
+        )
+        await uow.users.save(existing_user)
+
+        use_case = GetLoginOptions(uow, salt_generator)
+        dto = GetLoginOptionsQueryDTO(username="existing.user")
+
+        response = await use_case(dto)
+        assert isinstance(response, GetLoginOptionsResponseDTO)
+        assert response.salt == valid_base64_salt
+        assert response.kdf_memory_cost == 100000
+        assert response.kdf_time_cost == 3
+        assert response.kdf_parallelism == 4
+        assert not uow.committed
+        assert not uow.rolled_back
+
+    @pytest.mark.asyncio
+    async def test_get_login_options_user_does_not_exist(self, uow, salt_generator):
+        use_case = GetLoginOptions(uow, salt_generator)
+        dto = GetLoginOptionsQueryDTO(username="nonexistent.user")
+
+        response = await use_case(dto)
+        assert isinstance(response, GetLoginOptionsResponseDTO)
+        # Should use the fake generator
+        assert response.salt == "fake_salt_nonexistent.user"
+        # Should use some safe defaults
+        assert response.kdf_memory_cost > 0
+        assert response.kdf_time_cost > 0
+        assert response.kdf_parallelism > 0
+        assert not uow.committed
+        assert not uow.rolled_back

--- a/api/tests/unit/application/test_register_user.py
+++ b/api/tests/unit/application/test_register_user.py
@@ -1,0 +1,70 @@
+import pytest
+
+from babylon.application.exceptions import UsernameAlreadyExistsError
+from babylon.application.use_cases.registration import (
+    RegisterUser,
+    RegisterUserCommandDTO,
+    RegisterUserResponseDTO,
+)
+from babylon.domain.exceptions import UsernameValidationError
+from babylon.domain.value_objects import Username
+
+
+class TestRegisterUser:
+    @pytest.mark.asyncio
+    async def test_register_user_happy_path(self, uow, valid_phc_hash):
+        use_case = RegisterUser(uow)
+        dto = RegisterUserCommandDTO(
+            username="john.doe",
+            server_auth_hash=valid_phc_hash,
+            salt="Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU=",
+            kdf_memory_cost=65536,
+            kdf_time_cost=3,
+            kdf_parallelism=4,
+        )
+        response = await use_case(dto)
+        assert isinstance(response, RegisterUserResponseDTO)
+        assert response.user_id is not None
+        assert uow.committed
+        user = await uow.users.find_by_username(Username("john.doe"))
+        assert user is not None
+        assert str(user.id.value) == response.user_id
+
+    @pytest.mark.asyncio
+    async def test_register_user_username_already_exists(
+        self, uow, valid_phc_hash, user_factory
+    ):
+        existing_user = user_factory("existing.user")
+        await uow.users.save(existing_user)
+
+        use_case = RegisterUser(uow)
+        dto = RegisterUserCommandDTO(
+            username="existing.user",
+            server_auth_hash=valid_phc_hash,
+            salt="Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU=",
+            kdf_memory_cost=65536,
+            kdf_time_cost=3,
+            kdf_parallelism=4,
+        )
+
+        with pytest.raises(UsernameAlreadyExistsError):
+            await use_case(dto)
+
+        assert not uow.committed
+        assert uow.rolled_back
+
+    @pytest.mark.asyncio
+    async def test_register_user_invalid_domain_details(self, uow, valid_phc_hash):
+        use_case = RegisterUser(uow)
+        dto = RegisterUserCommandDTO(
+            username="a",  # Invalid username length
+            server_auth_hash=valid_phc_hash,
+            salt="Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU=",
+            kdf_memory_cost=65536,
+            kdf_time_cost=3,
+            kdf_parallelism=4,
+        )
+        with pytest.raises(UsernameValidationError):
+            await use_case(dto)
+        assert not uow.committed
+        assert uow.rolled_back

--- a/api/tests/unit/application/test_rotate_credentials.py
+++ b/api/tests/unit/application/test_rotate_credentials.py
@@ -1,0 +1,93 @@
+import uuid
+
+import pytest
+
+from babylon.application.exceptions import InvalidCredentialsError, UserNotFoundError
+from babylon.application.use_cases.credential_rotation import (
+    RotateCredentials,
+    RotateCredentialsCommandDTO,
+)
+
+
+@pytest.fixture
+def new_valid_phc_hash() -> str:
+    """Fixture for a valid PHC hash."""
+    return "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$dmFsaWRoYXNoZm9ydGVzdGluZw=="
+
+
+class TestRotateCredentials:
+    @pytest.mark.asyncio
+    async def test_rotate_credentials_happy_path(
+        self, uow, user_factory, valid_phc_hash, new_valid_phc_hash
+    ):
+        existing_user = user_factory("test.user")
+        original_version = existing_user.version.value
+        await uow.users.save(existing_user)
+
+        use_case = RotateCredentials(uow)
+
+        dto = RotateCredentialsCommandDTO(
+            user_id=str(existing_user.id.value),
+            current_server_auth_hash=valid_phc_hash,
+            new_salt="Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU=",
+            new_server_auth_hash=new_valid_phc_hash,
+            new_kdf_memory_cost=100000,
+            new_kdf_time_cost=4,
+            new_kdf_parallelism=2,
+        )
+
+        await use_case(dto)
+        assert uow.committed
+
+        # Check updated user
+        user = await uow.users.find_by_id(existing_user.id)
+        assert user.salt.value == "Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU="
+        assert user.server_authentication_hash.value == new_valid_phc_hash
+        assert user.kdf_configuration.memory_kb == 100000
+        assert user.kdf_configuration.iterations == 4
+        assert user.kdf_configuration.parallelism == 2
+        assert user.version.value == original_version + 1
+
+    @pytest.mark.asyncio
+    async def test_rotate_credentials_user_not_found(self, uow, valid_phc_hash):
+        use_case = RotateCredentials(uow)
+        dto = RotateCredentialsCommandDTO(
+            user_id=str(uuid.uuid7()),
+            current_server_auth_hash=valid_phc_hash,
+            new_salt="Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU=",
+            new_server_auth_hash=valid_phc_hash,
+            new_kdf_memory_cost=100000,
+            new_kdf_time_cost=4,
+            new_kdf_parallelism=2,
+        )
+
+        with pytest.raises(UserNotFoundError):
+            await use_case(dto)
+
+        assert not uow.committed
+        assert uow.rolled_back
+
+    @pytest.mark.asyncio
+    async def test_rotate_credentials_wrong_hash(
+        self, uow, user_factory, valid_phc_hash, new_valid_phc_hash
+    ):
+        existing_user = user_factory("test.user")
+        await uow.users.save(existing_user)
+
+        use_case = RotateCredentials(uow)
+
+        dto = RotateCredentialsCommandDTO(
+            user_id=str(existing_user.id.value),
+            current_server_auth_hash=new_valid_phc_hash,
+            new_salt="Y29ycmVjdF9zYWx0X3ZhbHVlX2hlcmU=",
+            new_server_auth_hash=valid_phc_hash,
+            new_kdf_memory_cost=100000,
+            new_kdf_time_cost=4,
+            new_kdf_parallelism=2,
+        )
+
+        with pytest.raises(InvalidCredentialsError):
+            await use_case(dto)
+
+        assert not uow.committed
+        assert uow.rolled_back


### PR DESCRIPTION
## Related Issue
Closes #5 

## Context & Intent
- The scope of this issue was to create the interactors and Use Cases for registering a new user, authenticate an existing one and also provide a credential rotation feature.

## What Changed
- Added Use cases for user authentication and registration
- Added DTO for communication with Presentation layer

## Security and Architectural Implication
- [ ] Introduced interface for random salt generator to prevent user enumeration attacks
- [x] No need for new ADR

## Testing Executed
- [x] Unit tests added/passed
- [x] Static analysis (Ruff/Mypy/Bandit) passed
- [x] Local Docker build passes